### PR TITLE
Add client support for job Update and Complete

### DIFF
--- a/internal/jobs/client.go
+++ b/internal/jobs/client.go
@@ -93,9 +93,9 @@ func (c *Client) request(ctx context.Context, date string, l url.URL) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return errors.New("wrong response status: " + resp.Status)
 	}
-	defer resp.Body.Close()
 	return nil
 }

--- a/internal/jobs/client.go
+++ b/internal/jobs/client.go
@@ -3,7 +3,7 @@ package jobs
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -64,7 +64,7 @@ func (c *Client) Lease(ctx context.Context) (string, error) {
 	}
 
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	return string(b), err
 }
 

--- a/internal/jobs/client.go
+++ b/internal/jobs/client.go
@@ -67,3 +67,40 @@ func (c *Client) Lease(ctx context.Context) (string, error) {
 	b, err := ioutil.ReadAll(resp.Body)
 	return string(b), err
 }
+
+// Update accepts a previously leased date and updates the date. Dates in
+// progress should be updated more frequently than the job-server lease timeout.
+func (c *Client) Update(ctx context.Context, date string) error {
+	l := *c.Server
+	l.Path = "/v1/update"
+	q := l.Query()
+	q.Add("date", date)
+	l.RawQuery = q.Encode()
+	resp, err := makeRequest(ctx, c.Client, &l)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("bad status: " + resp.Status)
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+// Complete accepts a previously leased date and marks it as complete.
+func (c *Client) Complete(ctx context.Context, date string) error {
+	l := *c.Server
+	l.Path = "/v1/complete"
+	q := l.Query()
+	q.Add("date", date)
+	l.RawQuery = q.Encode()
+	resp, err := makeRequest(ctx, c.Client, &l)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("bad status: " + resp.Status)
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/internal/jobs/client.go
+++ b/internal/jobs/client.go
@@ -73,24 +73,19 @@ func (c *Client) Lease(ctx context.Context) (string, error) {
 func (c *Client) Update(ctx context.Context, date string) error {
 	l := *c.Server
 	l.Path = "/v1/update"
-	q := l.Query()
-	q.Add("date", date)
-	l.RawQuery = q.Encode()
-	resp, err := makeRequest(ctx, c.Client, &l)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return errors.New("bad status: " + resp.Status)
-	}
-	defer resp.Body.Close()
-	return nil
+	return c.request(ctx, date, l)
 }
 
 // Complete accepts a previously leased date and marks it as complete.
 func (c *Client) Complete(ctx context.Context, date string) error {
 	l := *c.Server
 	l.Path = "/v1/complete"
+	return c.request(ctx, date, l)
+}
+
+// request issues a connection to given url with a single date parameter. Any
+// non-200 response is an error.
+func (c *Client) request(ctx context.Context, date string, l url.URL) error {
 	q := l.Query()
 	q.Add("date", date)
 	l.RawQuery = q.Encode()
@@ -99,7 +94,7 @@ func (c *Client) Complete(ctx context.Context, date string) error {
 		return err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return errors.New("bad status: " + resp.Status)
+		return errors.New("wrong response status: " + resp.Status)
 	}
 	defer resp.Body.Close()
 	return nil

--- a/internal/jobs/client_test.go
+++ b/internal/jobs/client_test.go
@@ -163,6 +163,12 @@ func TestClient_Update_and_Complete(t *testing.T) {
 				t.Errorf("Client.Complete() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+			if tt.wantErr {
+				return
+			}
+			if _, ok := h.jobs.Completed[tt.update]; !ok {
+				t.Errorf("Client.Complete() missing date: %s", tt.update)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This change continues https://github.com/m-lab/archive-repacker/pull/12 by adding client support to `Update()` and `Complete()` a date.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/archive-repacker/13)
<!-- Reviewable:end -->
