### PR TITLE
Add support for renaming objects

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -69,6 +69,9 @@ steps:
         --from-file=k8s/reannotator-query.sql --dry-run -o yaml | \
         /builder/kubectl.bash apply -f -
 
+    # Jobs cannot be applied before removing the old one.
+    /builder/kubectl.bash delete job init-job-server
+    /builder/kubectl.bash delete job reannotator
     /builder/kubectl.bash apply -f k8s/reannotator.yaml
   env:
   - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION

--- a/internal/annotation/renamer.go
+++ b/internal/annotation/renamer.go
@@ -1,0 +1,104 @@
+package annotation
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"cloud.google.com/go/storage"
+
+	"github.com/m-lab/archive-repacker/archive"
+	"github.com/m-lab/go/storagex"
+)
+
+// Renamer manages GCS operations to rename objects from one datatype to a new datatype.
+type Renamer struct {
+	client       *storage.Client
+	bucket       string
+	fromDatatype string
+	newDatatype  string
+}
+
+// NewRenamer creates a new Renamer. Objects are listed from bucket and written to bucket.
+func NewRenamer(client *storage.Client, bucket, fromDatatype, newDatatype string) *Renamer {
+	return &Renamer{
+		client:       client,
+		bucket:       bucket,
+		fromDatatype: fromDatatype,
+		newDatatype:  newDatatype,
+	}
+}
+
+// List returns GCS URLs for every fromDatatype object under the given date prefix.
+func (r *Renamer) List(ctx context.Context, date string) ([]string, error) {
+	d, err := civil.ParseDate(date)
+	if err != nil {
+		return nil, err
+	}
+	prefix := fmt.Sprintf("ndt/%s/%04d/%02d/%02d", r.fromDatatype, d.Year, d.Month, d.Day)
+	var results []string
+	log.Printf("Listing files under: gs://%s/%s", r.bucket, prefix)
+	bucket := storagex.NewBucket(r.client.Bucket(r.bucket))
+
+	// Individual days should only have 10-20k files.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+
+	for trial := 0; trial < 2; trial++ {
+		results = []string{}
+		err = bucket.Walk(ctx, prefix+"/", func(o *storagex.Object) error {
+			object := "gs://" + r.bucket + "/" + o.ObjectName()
+			results = append(results, object)
+			return nil
+		})
+		if err != nil {
+			log.Printf("retrying; list of %q returned error: %v", prefix, err)
+			continue
+		}
+		break
+	}
+	log.Printf("List found %d files for %q", len(results), prefix)
+	return results, err
+}
+
+// Rename copies the named URL to a new object, replacing fromDatatype with
+// newDatatype in the object name.
+func (r *Renamer) Rename(ctx context.Context, url string) (string, error) {
+	src, err := archive.ParseArchiveURL(url)
+	if err != nil {
+		return "", err
+	}
+	// Copy bucket & object path.
+	dst := src.Dup(r.bucket)
+	// Example annotation object path:
+	// * src: gs:/bucket1/ndt/annotation/2023/03/01/20230302T031500.576788Z-annotation-mlab1-chs0t-ndt.tgz
+	// * dst: gs:/bucket2/ndt/annotation2/2023/03/01/20230302T031500.576788Z-annotation2-mlab1-chs0t-ndt.tgz
+	//
+	// Note: bucket1 and bucket2 could be the same value.
+	//
+	// Replace the original datatype with the new one.
+	dst.Path = strings.ReplaceAll(dst.Path, r.fromDatatype+"-", r.newDatatype+"-")
+	dst.Path = strings.ReplaceAll(dst.Path, r.fromDatatype+"/", r.newDatatype+"/")
+
+	// Individual files (under ~50MB) should not take longer than an hour.
+	ctx, cancel := context.WithTimeout(ctx, time.Hour)
+	defer cancel()
+
+	srcObj := r.client.Bucket(src.Bucket()).Object(src.Object())
+	dstObj := r.client.Bucket(dst.Bucket()).Object(dst.Object())
+
+	// Unconditionally overwrite the dst object.
+	// Note: Copiers go through the client: read from GCS then write to GCS.
+	for trial := 0; trial < 2; trial++ {
+		_, err := dstObj.CopierFrom(srcObj).Run(ctx)
+		if err != nil {
+			log.Printf("Failed to copy %q, err: %v", dst, err)
+			continue
+		}
+		break
+	}
+	return dst.String(), err
+}

--- a/internal/annotation/renamer.go
+++ b/internal/annotation/renamer.go
@@ -39,14 +39,14 @@ func (r *Renamer) List(ctx context.Context, date string) ([]string, error) {
 		return nil, err
 	}
 	prefix := fmt.Sprintf("ndt/%s/%04d/%02d/%02d", r.fromDatatype, d.Year, d.Month, d.Day)
-	var results []string
 	log.Printf("Listing files under: gs://%s/%s", r.bucket, prefix)
-	bucket := storagex.NewBucket(r.client.Bucket(r.bucket))
 
 	// Individual days should only have 10-20k files.
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
 
+	var results []string
+	bucket := storagex.NewBucket(r.client.Bucket(r.bucket))
 	for trial := 0; trial < 2; trial++ {
 		results = []string{}
 		err = bucket.Walk(ctx, prefix+"/", func(o *storagex.Object) error {
@@ -59,6 +59,9 @@ func (r *Renamer) List(ctx context.Context, date string) ([]string, error) {
 			continue
 		}
 		break
+	}
+	if err != nil {
+		return nil, err
 	}
 	log.Printf("List found %d files for %q", len(results), prefix)
 	return results, err

--- a/internal/annotation/renamer.go
+++ b/internal/annotation/renamer.go
@@ -18,15 +18,17 @@ import (
 type Renamer struct {
 	client       *storage.Client
 	bucket       string
+	experiment   string
 	fromDatatype string
 	newDatatype  string
 }
 
 // NewRenamer creates a new Renamer. Objects are listed from bucket and written to bucket.
-func NewRenamer(client *storage.Client, bucket, fromDatatype, newDatatype string) *Renamer {
+func NewRenamer(client *storage.Client, bucket, experiment, fromDatatype, newDatatype string) *Renamer {
 	return &Renamer{
 		client:       client,
 		bucket:       bucket,
+		experiment:   experiment,
 		fromDatatype: fromDatatype,
 		newDatatype:  newDatatype,
 	}
@@ -38,7 +40,7 @@ func (r *Renamer) List(ctx context.Context, date string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	prefix := fmt.Sprintf("ndt/%s/%04d/%02d/%02d", r.fromDatatype, d.Year, d.Month, d.Day)
+	prefix := fmt.Sprintf("%s/%s/%04d/%02d/%02d", r.experiment, r.fromDatatype, d.Year, d.Month, d.Day)
 	log.Printf("Listing files under: gs://%s/%s", r.bucket, prefix)
 
 	// Individual days should only have 10-20k files.

--- a/internal/annotation/renamer.go
+++ b/internal/annotation/renamer.go
@@ -88,6 +88,11 @@ func (r *Renamer) Rename(ctx context.Context, url string) (string, error) {
 	dst.Path = strings.ReplaceAll(dst.Path, r.fromDatatype+"-", r.newDatatype+"-")
 	dst.Path = strings.ReplaceAll(dst.Path, r.fromDatatype+"/", r.newDatatype+"/")
 
+	// Paths are identical, so there is nothing to rename.
+	if src.String() == dst.String() {
+		return dst.String(), nil
+	}
+
 	// Individual files (under ~50MB) should not take longer than an hour.
 	ctx, cancel := context.WithTimeout(ctx, time.Hour)
 	defer cancel()

--- a/internal/annotation/renamer_test.go
+++ b/internal/annotation/renamer_test.go
@@ -1,0 +1,194 @@
+package annotation
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/m-lab/archive-repacker/archive"
+
+	"github.com/fsouza/fake-gcs-server/fakestorage"
+	"github.com/m-lab/go/testingx"
+)
+
+func TestRenamer_List(t *testing.T) {
+	tests := []struct {
+		name         string
+		date         string
+		bucket       string
+		fromDatatype string
+		newDatatype  string
+		want         []string
+		wantErr      bool
+	}{
+		{
+			name:         "success",
+			date:         "2023-03-01",
+			bucket:       "fake-bucket",
+			fromDatatype: "annotation",
+			newDatatype:  "annotation2",
+			want: []string{
+				"gs://fake-bucket/ndt/annotation/2023/03/01/20230302T031500.576788Z-annotation-mlab1-chs0t-ndt.tgz",
+				"gs://fake-bucket/ndt/annotation/2023/03/01/20230302T031500.123450Z-annotation-mlab2-chs0t-ndt.tgz",
+			},
+		},
+		{
+			name:    "error-bad-date",
+			date:    "-this-is-not-a-date-",
+			wantErr: true,
+		},
+		{
+			name:    "error-cannot-walk-bad-bucket",
+			date:    "2023-03-01",
+			bucket:  "this-bucket-does-not-exist",
+			wantErr: true,
+		},
+	}
+
+	// * src: gs:/bucket1/ndt/annotation/2023/03/01/20230302T031500.576788Z-annotation-mlab1-chs0t-ndt.tgz
+	// * dst: gs:/bucket2/ndt/annotation2/2023/03/01/20230302T031500.576788Z-annotation2-mlab1-chs0t-ndt.tgz
+	objs := []fakestorage.Object{
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: "fake-bucket",
+				Name:       "ndt/annotation/2023/03/01/20230302T031500.576788Z-annotation-mlab1-chs0t-ndt.tgz",
+				Updated:    time.Now(),
+			},
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: "fake-bucket",
+				Name:       "ndt/annotation/2023/03/01/20230302T031500.123450Z-annotation-mlab2-chs0t-ndt.tgz",
+				Updated:    time.Now(),
+			},
+		},
+	}
+	server, err := fakestorage.NewServerWithOptions(fakestorage.Options{
+		InitialObjects:  objs,
+		BucketsLocation: "US",
+	})
+	testingx.Must(t, err, "error initializing GCS server")
+	defer server.Stop()
+	client := server.Client()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Renamer{
+				client:       client,
+				bucket:       tt.bucket,
+				fromDatatype: tt.fromDatatype,
+				newDatatype:  tt.newDatatype,
+			}
+			got, err := r.List(context.Background(), tt.date)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Renamer.List() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			// Return order is not guaranteed; sort so comparison is fair.
+			sort.Strings(got)
+			sort.Strings(tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Renamer.List() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenamer_Rename(t *testing.T) {
+	tests := []struct {
+		name         string
+		bucket       string
+		fromDatatype string
+		newDatatype  string
+		url          string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:         "success-rename-annotation2-archive",
+			bucket:       "fake-bucket",
+			fromDatatype: "annotation",
+			newDatatype:  "annotation2",
+			url:          "gs://fake-bucket/ndt/annotation/2023/03/01/20230302T031500.576788Z-annotation-mlab1-chs0t-ndt.tgz",
+			want:         "gs://fake-bucket/ndt/annotation2/2023/03/01/20230302T031500.576788Z-annotation2-mlab1-chs0t-ndt.tgz",
+		},
+		{
+			name:         "success-rename-hopannotation2-archive",
+			bucket:       "fake-bucket",
+			fromDatatype: "hopannotation1",
+			newDatatype:  "hopannotation2",
+			url:          "gs://fake-bucket/ndt/hopannotation1/2023/03/01/20230302T031500.123450Z-hopannotation1-mlab2-chs0t-ndt.tgz",
+			want:         "gs://fake-bucket/ndt/hopannotation2/2023/03/01/20230302T031500.123450Z-hopannotation2-mlab2-chs0t-ndt.tgz",
+		},
+		{
+			name:    "error-bad-url",
+			url:     "-this-is:-invalid-url",
+			wantErr: true,
+		},
+	}
+	objs := []fakestorage.Object{
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: "fake-bucket",
+				Name:       "ndt/annotation/2023/03/01/20230302T031500.576788Z-annotation-mlab1-chs0t-ndt.tgz",
+				Updated:    time.Now(),
+			},
+			Content: []byte{0, 1, 2, 3, 4},
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: "fake-bucket",
+				Name:       "ndt/hopannotation1/2023/03/01/20230302T031500.123450Z-hopannotation1-mlab2-chs0t-ndt.tgz",
+				Updated:    time.Now(),
+			},
+			Content: []byte{0, 1, 2, 3, 4},
+		},
+	}
+	server, err := fakestorage.NewServerWithOptions(fakestorage.Options{
+		InitialObjects:  objs,
+		BucketsLocation: "US",
+	})
+	testingx.Must(t, err, "error initializing GCS server")
+	defer server.Stop()
+	client := server.Client()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			r := NewRenamer(client, tt.bucket, tt.fromDatatype, tt.newDatatype)
+			got, err := r.Rename(ctx, tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Renamer.Rename() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Renamer.Rename() = \n%v, want \n%v", got, tt.want)
+			}
+			if tt.wantErr {
+				return
+			}
+			s, err := archive.ParseArchiveURL(tt.url)
+			testingx.Must(t, err, "failed to parse archive url: %s", tt.url)
+			d, err := archive.ParseArchiveURL(got)
+			testingx.Must(t, err, "failed to parse output url: %s", got)
+			// Verify output objects are in GCS.
+			src := client.Bucket(s.Bucket()).Object(s.Object())
+			srcattr, err := src.Attrs(context.Background())
+			testingx.Must(t, err, "failed to read attrs")
+
+			dst := client.Bucket(d.Bucket()).Object(d.Object())
+			dstattr, err := dst.Attrs(context.Background())
+			testingx.Must(t, err, "failed to read attrs")
+
+			if srcattr.Size != dstattr.Size {
+				t.Errorf("Renamer.Rename() wrong object size; got %d, want %d", dstattr.Size, srcattr.Size)
+			}
+		})
+	}
+}

--- a/internal/annotation/renamer_test.go
+++ b/internal/annotation/renamer_test.go
@@ -72,7 +72,7 @@ func TestRenamer_List(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := NewRenamer(client, tt.bucket, tt.fromDatatype, tt.newDatatype)
+			r := NewRenamer(client, tt.bucket, "ndt", tt.fromDatatype, tt.newDatatype)
 			got, err := r.List(context.Background(), tt.date)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Renamer.List() error = %v, wantErr %v", err, tt.wantErr)
@@ -152,7 +152,7 @@ func TestRenamer_Rename(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := NewRenamer(client, tt.bucket, tt.fromDatatype, tt.newDatatype)
+			r := NewRenamer(client, tt.bucket, "ndt", tt.fromDatatype, tt.newDatatype)
 			got, err := r.Rename(context.Background(), tt.url)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Renamer.Rename() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/annotation/renamer_test.go
+++ b/internal/annotation/renamer_test.go
@@ -119,6 +119,14 @@ func TestRenamer_Rename(t *testing.T) {
 			want:         "gs://fake-bucket/ndt/hopannotation2/2023/03/01/20230302T031500.123450Z-hopannotation2-mlab2-chs0t-ndt.tgz",
 		},
 		{
+			name:         "success-noop",
+			bucket:       "fake-bucket",
+			fromDatatype: "hopannotation2",
+			newDatatype:  "hopannotation2",
+			url:          "gs://fake-bucket/ndt/hopannotation2/2023/03/01/20230302T031500.123450Z-hopannotation2-mlab2-chs0t-ndt.tgz",
+			want:         "gs://fake-bucket/ndt/hopannotation2/2023/03/01/20230302T031500.123450Z-hopannotation2-mlab2-chs0t-ndt.tgz",
+		},
+		{
 			name:    "error-bad-url",
 			url:     "-this-is:-invalid-url",
 			wantErr: true,


### PR DESCRIPTION
This change adds a new type, `annotation.Renamer`. This enables bulk operations to rename GCS objects from one datatype to another, e.g. annotation to annotation2.

Both `List` and `Rename` include a retry to make these base operations more resilient to transient failures.

Ultimately, the `Renamer` will be part of a date job processor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/archive-repacker/19)
<!-- Reviewable:end -->
