### PR TITLE
Add renamer command

### DIFF
--- a/Dockerfile.reannotator
+++ b/Dockerfile.reannotator
@@ -7,14 +7,19 @@ RUN go get -v ./...
 RUN go install \
       -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)$(git diff --quiet || echo dirty)" \
       ./cmd/reannotator
+RUN go install \
+      -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)$(git diff --quiet || echo dirty)" \
+      ./cmd/renamer
 
 FROM alpine:3.17
 # By default, alpine has no root certs. Add them so pusher can use PKI to
 # verify that Google Cloud Storage is actually Google Cloud Storage.
 RUN apk add --no-cache ca-certificates
 COPY --from=build /go/bin/reannotator /
+COPY --from=build /go/bin/renamer /
 COPY --from=measurementlab/uuid-annotator:latest /data/asnames.ipinfo.csv /data/asnames.ipinfo.csv
 WORKDIR /
 # Make sure /reannotator can run (has no missing external dependencies).
 RUN /reannotator -h 2> /dev/null
+RUN /renamer -h 2> /dev/null
 ENTRYPOINT ["/reannotator"]

--- a/cmd/renamer/main.go
+++ b/cmd/renamer/main.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/m-lab/archive-repacker/internal/jobs"
+	"github.com/m-lab/archive-repacker/internal/process"
+	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/prometheusx"
+	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/go/timex"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	jobservice   = flagx.URL{}
+	outBucket    string
+	fromDatatype string
+	newDatatype  string
+	oneDate      string
+
+	mainCtx, mainCancel = context.WithCancel(context.Background())
+)
+var (
+	renamerDatesStarted = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "renamer_dates_started_total",
+			Help: "The number of dates started",
+		},
+	)
+	renamerDate = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renamer_date",
+			Help: "Most recent date processed.",
+		},
+		[]string{"state"},
+	)
+	renamerDateCompletionTime = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name: "renamer_date_completion_time",
+			Help: "Histogram of job completion times",
+			Buckets: []float64{
+				10, 21.5, 46.4,
+				100, 215, 464,
+				1000, 2150, 4640,
+				10000, 21500, 46400,
+			},
+		},
+	)
+)
+
+func init() {
+	flag.Var(&jobservice, "jobservice.url", "The URL for the job service providing dates to process.")
+	flag.StringVar(&outBucket, "output", "annotation2-output-mlab-sandbox", "Write generated archives to this GCS Bucket.")
+	flag.StringVar(&fromDatatype, "from-datatype", "annotation", "Name of original datatype to read in.")
+	flag.StringVar(&newDatatype, "new-datatype", "annotation2", "Name of new datatype to write out.")
+	flag.StringVar(&oneDate, "date", "", "If provided, process only this single date.")
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
+func main() {
+	defer mainCancel()
+	flag.Parse()
+	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from env")
+
+	prometheusx.MustServeMetrics()
+	//sclient, err := storage.NewClient(mainCtx, option.WithScopes(storage.ScopeReadWrite))
+	//rtx.Must(err, "failed to create new read/write storage client")
+	// p := annotation.NewRenamer(sclient, outBucket, fromDatatype, newDatatype)
+	r := &process.Copier{
+		Process: nil,
+	}
+	if oneDate != "" {
+		processDate(r, oneDate)
+		return
+	}
+	r.Jobs = jobs.NewClient(jobservice.URL, http.DefaultClient)
+
+	// Process jobs indefinitely.
+	for {
+		date, err := r.Jobs.Lease(mainCtx)
+		switch err {
+		case jobs.ErrEmpty:
+			log.Println("Work queue empty; exiting")
+			return
+		case jobs.ErrWait:
+			log.Println("Work queue pending; waiting for 1m")
+			time.Sleep(time.Minute)
+			continue
+		}
+		rtx.Must(err, "failed to request job lease")
+
+		processDate(r, date)
+
+		err = r.Jobs.Complete(mainCtx, date)
+		rtx.Must(err, "failed to complete job with job service: %s", date)
+	}
+}
+
+func processDate(r *process.Copier, date string) {
+
+	d, err := time.Parse(timex.YYYYMMDDWithDash, date)
+	rtx.Must(err, "failed to parse job date")
+
+	t := time.Now()
+	log.Println("Starting date:", date)
+	renamerDate.WithLabelValues("starting").Set(float64(d.Unix()))
+	renamerDatesStarted.Inc()
+
+	err = r.ProcessDate(mainCtx, date)
+	rtx.Must(err, "failed to run job to completion: %s", date)
+
+	log.Println("Completed date:", date, time.Since(t))
+	renamerDate.WithLabelValues("completed").Set(float64(d.Unix()))
+	renamerDateCompletionTime.Observe(time.Since(t).Seconds())
+}

--- a/cmd/renamer/main.go
+++ b/cmd/renamer/main.go
@@ -109,7 +109,6 @@ func main() {
 }
 
 func processDate(r *process.Copier, date string) {
-
 	d, err := time.Parse(timex.YYYYMMDDWithDash, date)
 	rtx.Must(err, "failed to parse job date")
 

--- a/internal/annotation/process.go
+++ b/internal/annotation/process.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/m-lab/archive-repacker/archive"
@@ -190,9 +189,5 @@ func (p *Processor) Finish(ctx context.Context, out *archive.Target) error {
 	uctx, ucancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer ucancel()
 	o := p.src.Path.Dup(p.outBucket)
-	// Example annotation object path:
-	// * ndt/annotation/2023/03/01/20230302T031500.576788Z-annotation-mlab1-chs0t-ndt.tgz
-	o.Path = strings.ReplaceAll(o.Path, "annotation-", "annotation2-")
-	o.Path = strings.ReplaceAll(o.Path, "annotation/", "annotation2/")
 	return out.Upload(uctx, p.client, o)
 }

--- a/internal/annotation/process_test.go
+++ b/internal/annotation/process_test.go
@@ -242,7 +242,7 @@ func TestProcessor_Finish(t *testing.T) {
 			},
 			outBucket: "fake-target-bucket",
 			fromURL:   "gs://fake-source-bucket/ndt/annotation/2023/03/01/20230302T031500.576788Z-annotation-mlab1-chs0t-ndt.tgz",
-			wantURL:   "gs://fake-target-bucket/ndt/annotation2/2023/03/01/20230302T031500.576788Z-annotation2-mlab1-chs0t-ndt.tgz",
+			wantURL:   "gs://fake-target-bucket/ndt/annotation/2023/03/01/20230302T031500.576788Z-annotation-mlab1-chs0t-ndt.tgz",
 		},
 	}
 

--- a/internal/process/copier.go
+++ b/internal/process/copier.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/m-lab/archive-repacker/internal/jobs"
@@ -23,7 +24,7 @@ type Copier struct {
 func (c *Copier) ProcessDate(ctx context.Context, date string) error {
 	l, err := c.Process.List(ctx, date)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list %s: %w", date, err)
 	}
 	for i := range l {
 		if i%1000 == 0 && c.Jobs != nil {
@@ -33,9 +34,10 @@ func (c *Copier) ProcessDate(ctx context.Context, date string) error {
 		}
 		_, err := c.Process.Rename(ctx, l[i])
 		if err != nil {
-			log.Printf("failed to rename %q: %v", l[i], err)
-			return err
+			log.Printf("Failed to rename %q: %v", l[i], err)
+			return fmt.Errorf("failed rename of %q: %w", l[i], err)
 		}
 	}
+	log.Printf("Renamed %d objects for %s", len(l), date)
 	return nil
 }

--- a/internal/process/copier.go
+++ b/internal/process/copier.go
@@ -1,0 +1,41 @@
+package process
+
+import (
+	"context"
+	"log"
+
+	"github.com/m-lab/archive-repacker/internal/jobs"
+)
+
+// Renamer is an interface for types that support renaming.
+type Renamer interface {
+	List(ctx context.Context, date string) ([]string, error)
+	Rename(ctx context.Context, url string) (string, error)
+}
+
+// Copier manages bulk rename operations.
+type Copier struct {
+	Jobs    *jobs.Client
+	Process Renamer
+}
+
+// ProcessDate applies the renamer to the given date.
+func (c *Copier) ProcessDate(ctx context.Context, date string) error {
+	l, err := c.Process.List(ctx, date)
+	if err != nil {
+		return err
+	}
+	for i := range l {
+		if i%1000 == 0 && c.Jobs != nil {
+			// Update every 100 operations.
+			log.Printf("Renamed %d objects for %s", i, date)
+			c.Jobs.Update(ctx, date)
+		}
+		_, err := c.Process.Rename(ctx, l[i])
+		if err != nil {
+			log.Printf("failed to rename %q: %v", l[i], err)
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/process/copier_test.go
+++ b/internal/process/copier_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/m-lab/archive-repacker/internal/jobs"
+	"github.com/m-lab/go/testingx"
 )
 
 type fakeRenamer struct {
@@ -70,7 +71,8 @@ func TestCopier_ProcessDate(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 	}))
 	s := httptest.NewServer(mux)
-	u, _ := url.Parse(s.URL)
+	u, err := url.Parse(s.URL)
+	testingx.Must(t, err, "failed to parse server url")
 	js := jobs.NewClient(u, http.DefaultClient)
 
 	for _, tt := range tests {

--- a/internal/process/copier_test.go
+++ b/internal/process/copier_test.go
@@ -1,0 +1,91 @@
+package process
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/m-lab/archive-repacker/internal/jobs"
+)
+
+type fakeRenamer struct {
+	list      []string
+	listErr   error
+	renameErr error
+	Count     int
+}
+
+func (f *fakeRenamer) List(ctx context.Context, date string) ([]string, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.list, nil
+}
+
+func (f *fakeRenamer) Rename(ctx context.Context, url string) (string, error) {
+	f.Count++
+	return "", f.renameErr
+}
+
+func TestCopier_ProcessDate(t *testing.T) {
+	tests := []struct {
+		name      string
+		date      string
+		renamer   *fakeRenamer
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name: "success",
+			date: "2023-03-01",
+			renamer: &fakeRenamer{
+				list: []string{"a", "b", "c", "d", "e"},
+			},
+			wantCount: 5,
+		},
+		{
+			name: "error-list-fails",
+			date: "2023-03-01",
+			renamer: &fakeRenamer{
+				listErr: errors.New("fake-list-error"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "error-rename-fails",
+			date: "2023-03-01",
+			renamer: &fakeRenamer{
+				list:      []string{"a", "b", "c", "d", "e"},
+				renameErr: errors.New("fake-rename-error"),
+			},
+			wantCount: 1,
+			wantErr:   true,
+		},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/update", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	s := httptest.NewServer(mux)
+	u, _ := url.Parse(s.URL)
+	js := jobs.NewClient(u, http.DefaultClient)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Copier{
+				Jobs:    js,
+				Process: tt.renamer,
+			}
+			ctx := context.Background()
+			if err := c.ProcessDate(ctx, tt.date); (err != nil) != tt.wantErr {
+				t.Errorf("Copier.ProcessDate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.renamer.Count != tt.wantCount {
+				t.Errorf("Copier.ProcessDate() wrong count = %d, want %d", tt.renamer.Count, tt.wantCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds a new `renamer` command to work with the `reannotator`.

The renamer command is another job-server client, taking one date, processing it and completing the date before continuing to the next. This change also adds a `process.Copier` type with tests. The renamer uses the `process.Copier` to perform the renaming operations on all GCS objects identified for the given date.

This change updates the Dockerfile to include the renamer, as an optional command.

Finally, this change removes the object renaming logic from `internal/annotation/process.go` in favor of the logic in `internal/annotation/renamer.go`.

The reannotator just reannotates. The renamer just renames.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/archive-repacker/20)
<!-- Reviewable:end -->
