### PR TITLE
Enable renamer for annotation2

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -55,43 +55,42 @@ steps:
   - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
   - CLOUDSDK_CONTAINER_CLUSTER=data-processing
 
-- name: gcr.io/cloud-builders/kubectl
-  id: "Deploy reannotator configuration"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |-
-    sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/g' \
-           -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/g' \
-           k8s/reannotator.yaml
-
-    /builder/kubectl.bash create configmap reannotator-config \
-        --from-file=k8s/reannotator-query.sql --dry-run -o yaml | \
-        /builder/kubectl.bash apply -f -
-
-    # Jobs cannot be applied before removing the old one.
-    /builder/kubectl.bash delete job init-job-server
-    /builder/kubectl.bash delete job reannotator
-    /builder/kubectl.bash apply -f k8s/reannotator.yaml
-  env:
-  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
-  - CLOUDSDK_CONTAINER_CLUSTER=data-processing
-
-# TODO(soltesz): enable after reannotator is completed.
 #- name: gcr.io/cloud-builders/kubectl
-#  id: "Deploy renamer configuration"
+#  id: "Deploy reannotator configuration"
 #  entrypoint: /bin/bash
 #  args:
 #  - -c
 #  - |-
 #    sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/g' \
 #           -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/g' \
-#           k8s/renamer.yaml
+#           k8s/reannotator.yaml
 #
-#    # Enable after reannotator has completed.
+#    /builder/kubectl.bash create configmap reannotator-config \
+#        --from-file=k8s/reannotator-query.sql --dry-run -o yaml | \
+#        /builder/kubectl.bash apply -f -
+#
+#    # Jobs cannot be applied before removing the old one.
 #    /builder/kubectl.bash delete job init-job-server
-#    /builder/kubectl.bash delete job renamer
-#    /builder/kubectl.bash apply -f k8s/renamer.yaml
+#    /builder/kubectl.bash delete job reannotator
+#    /builder/kubectl.bash apply -f k8s/reannotator.yaml
 #  env:
 #  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
 #  - CLOUDSDK_CONTAINER_CLUSTER=data-processing
+
+- name: gcr.io/cloud-builders/kubectl
+  id: "Deploy renamer configuration"
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |-
+    sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/g' \
+           -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/g' \
+           k8s/renamer.yaml
+
+    # Enable after reannotator has completed.
+    /builder/kubectl.bash delete job init-job-server
+    /builder/kubectl.bash delete job renamer
+    /builder/kubectl.bash apply -f k8s/renamer.yaml
+  env:
+  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
+  - CLOUDSDK_CONTAINER_CLUSTER=data-processing

--- a/k8s/renamer.yaml
+++ b/k8s/renamer.yaml
@@ -11,11 +11,11 @@ spec:
       - name: busybox
         image: busybox
         args:
+        # Full history of annotation archives.
         - wget
-        # Init a single date for testing.
-        - http://$(JOB_SERVER_PORT_8083_TCP_ADDR):$(JOB_SERVER_PORT_8083_TCP_PORT)/v1/init?start=2023-02-10&end=2023-02-11
-        # TODO(soltesz): initialize complete time range for production deployment.
-        # - http://$(JOB_SERVER_PORT_8083_TCP_ADDR):$(JOB_SERVER_PORT_8083_TCP_PORT)/v1/init?start=2020-03-10&end=2023-02-11
+        - http://$(JOB_SERVER_PORT_8083_TCP_ADDR):$(JOB_SERVER_PORT_8083_TCP_PORT)/v1/init?start=2019-04-01&end=2023-04-04
+        # TODO(soltesz): operate on fully history of hopannotation1 archives.
+        # - http://$(JOB_SERVER_PORT_8083_TCP_ADDR):$(JOB_SERVER_PORT_8083_TCP_PORT)/v1/init?start=2019-06-04&end=2023-04-04
       restartPolicy: Never
 ---
 apiVersion: batch/v1


### PR DESCRIPTION
This change is the next portion of the reannotation process, renaming archives from the old name to the new name.

The reannotator only needed to be applied to a short time range. The renamer is applied to the complete history of annotation datatype to produce a complete history with the annotation2 type.

This change also deletes the source archive after copy to create clear evidence of a completed job (all job dates run and there are no remaining old archives).

Part of:
* https://github.com/m-lab/data-annotations/issues/34

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/archive-repacker/23)
<!-- Reviewable:end -->
