### PR TITLE
Simplify tests and disable job deployments

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -77,20 +77,20 @@ steps:
 #  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
 #  - CLOUDSDK_CONTAINER_CLUSTER=data-processing
 
-- name: gcr.io/cloud-builders/kubectl
-  id: "Deploy renamer configuration"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |-
-    sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/g' \
-           -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/g' \
-           k8s/renamer.yaml
-
-    # Enable after reannotator has completed.
-    /builder/kubectl.bash delete job init-job-server
-    /builder/kubectl.bash delete job renamer
-    /builder/kubectl.bash apply -f k8s/renamer.yaml
-  env:
-  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
-  - CLOUDSDK_CONTAINER_CLUSTER=data-processing
+#- name: gcr.io/cloud-builders/kubectl
+#  id: "Deploy renamer configuration"
+#  entrypoint: /bin/bash
+#  args:
+#  - -c
+#  - |-
+#    sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/g' \
+#           -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/g' \
+#           k8s/renamer.yaml
+#
+#    # Enable after reannotator has completed.
+#    /builder/kubectl.bash delete job init-job-server
+#    /builder/kubectl.bash delete job renamer
+#    /builder/kubectl.bash apply -f k8s/renamer.yaml
+#  env:
+#  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
+#  - CLOUDSDK_CONTAINER_CLUSTER=data-processing

--- a/internal/annotation/process_test.go
+++ b/internal/annotation/process_test.go
@@ -143,9 +143,7 @@ func TestProcessor_File(t *testing.T) {
 		name    string
 		fromURL string
 		files   map[string]string
-		src     *archive.Source
 		netAnn  *annotator.Network
-		want    []byte
 		wantErr bool
 	}{
 		{
@@ -207,7 +205,7 @@ func TestProcessor_File(t *testing.T) {
 			testingx.Must(t, err, "failed to unmarshal processor result")
 			// Verify that output is well formatted.
 			if !reflect.DeepEqual(an.Client.Network, tt.netAnn) {
-				t.Errorf("Processor.File() = %v, want %v", an, tt.want)
+				t.Errorf("Processor.File() = %v, want %v", an.Client.Network, tt.netAnn)
 			}
 		})
 	}
@@ -229,11 +227,9 @@ func TestProcessor_Finish(t *testing.T) {
 	tests := []struct {
 		name      string
 		files     map[string]string
-		src       *archive.Source
 		outBucket string
 		fromURL   string
 		wantURL   string
-		wantErr   bool
 	}{
 		{
 			name: "success",
@@ -285,8 +281,9 @@ func TestProcessor_Finish(t *testing.T) {
 			}
 			out := createTargetFromSource(src)
 			err = p.Finish(ctx, out)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Processor.Finish() error = %v, wantErr %v", err, tt.wantErr)
+			if err != nil {
+				t.Errorf("Processor.Finish() error = %v, want nil", err)
+				return
 			}
 			// Verify new file is in the fake-target-bucket.
 			src2, err := archive.NewGCSSource(ctx, client, tt.wantURL)


### PR DESCRIPTION
This change disables job deployments for the annotation renamer and removes unnecessary fields from tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/archive-repacker/25)
<!-- Reviewable:end -->
