### PR TITLE
Add support to reannotator for hopannotation1 datatype

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -55,27 +55,27 @@ steps:
   - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
   - CLOUDSDK_CONTAINER_CLUSTER=data-processing
 
-#- name: gcr.io/cloud-builders/kubectl
-#  id: "Deploy reannotator configuration"
-#  entrypoint: /bin/bash
-#  args:
-#  - -c
-#  - |-
-#    sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/g' \
-#           -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/g' \
-#           k8s/reannotator.yaml
-#
-#    /builder/kubectl.bash create configmap reannotator-config \
-#        --from-file=k8s/reannotator-query.sql --dry-run -o yaml | \
-#        /builder/kubectl.bash apply -f -
-#
-#    # Jobs cannot be applied before removing the old one.
-#    /builder/kubectl.bash delete job init-job-server
-#    /builder/kubectl.bash delete job reannotator
-#    /builder/kubectl.bash apply -f k8s/reannotator.yaml
-#  env:
-#  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
-#  - CLOUDSDK_CONTAINER_CLUSTER=data-processing
+- name: gcr.io/cloud-builders/kubectl
+  id: "Deploy reannotator configuration"
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |-
+    sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/g' \
+           -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/g' \
+           k8s/reannotator.yaml
+
+    /builder/kubectl.bash create configmap reannotator-config \
+        --from-file=k8s/reannotator-query-hopannotation1.sql --dry-run -o yaml | \
+        /builder/kubectl.bash apply -f -
+
+    # Jobs cannot be applied before removing the old one.
+    /builder/kubectl.bash delete job init-job-server
+    /builder/kubectl.bash delete job reannotator
+    /builder/kubectl.bash apply -f k8s/reannotator.yaml
+  env:
+  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
+  - CLOUDSDK_CONTAINER_CLUSTER=data-processing
 
 #- name: gcr.io/cloud-builders/kubectl
 #  id: "Deploy renamer configuration"

--- a/k8s/reannotator-query-hopannotation1.sql
+++ b/k8s/reannotator-query-hopannotation1.sql
@@ -1,0 +1,9 @@
+SELECT
+  parser.ArchiveURL as ArchiveURL,
+  [STRUCT("" as Filename, "" as DstIP)] as Files
+FROM
+  `measurement-lab.ndt_raw.hopannotation1`
+WHERE
+  date = @date
+GROUP BY
+  ArchiveURL

--- a/k8s/reannotator.yaml
+++ b/k8s/reannotator.yaml
@@ -44,7 +44,8 @@ spec:
         - -routeview-v4.url=gs://downloader-{{PROJECT_ID}}/RouteViewIPv4/
         - -routeview-v6.url=gs://downloader-{{PROJECT_ID}}/RouteViewIPv6/
         - -asname.url=file:/data/asnames.ipinfo.csv
-        - -query=/config/reannotator-query.sql
+        - -query=/config/reannotator-query-hopannotation1.sql
+        - -datatype=hopannotation1
         - -output=annotation2-output-{{PROJECT_ID}}
         - -prometheusx.listen-address=:9990
         ports:


### PR DESCRIPTION
This change adds support for the hopannotation1 datatype to the reannotator command. This change also adds a new query to return all hopannotation1 archives to be processed by the reannotator. And, finally this change updates the flags given to the reannotator Kubernetes job to include the new query and hopannotation1 dataype.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/archive-repacker/27)
<!-- Reviewable:end -->
