### PR TITLE
Enable renamer configuration for hopannotation2

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -55,42 +55,42 @@ steps:
   - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
   - CLOUDSDK_CONTAINER_CLUSTER=data-processing
 
-- name: gcr.io/cloud-builders/kubectl
-  id: "Deploy reannotator configuration"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |-
-    sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/g' \
-           -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/g' \
-           k8s/reannotator.yaml
-
-    /builder/kubectl.bash create configmap reannotator-config \
-        --from-file=k8s/reannotator-query-hopannotation1.sql --dry-run -o yaml | \
-        /builder/kubectl.bash apply -f -
-
-    # Jobs cannot be applied before removing the old one.
-    /builder/kubectl.bash delete job init-job-server
-    /builder/kubectl.bash delete job reannotator
-    /builder/kubectl.bash apply -f k8s/reannotator.yaml
-  env:
-  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
-  - CLOUDSDK_CONTAINER_CLUSTER=data-processing
-
 #- name: gcr.io/cloud-builders/kubectl
-#  id: "Deploy renamer configuration"
+#  id: "Deploy reannotator configuration"
 #  entrypoint: /bin/bash
 #  args:
 #  - -c
 #  - |-
 #    sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/g' \
 #           -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/g' \
-#           k8s/renamer.yaml
+#           k8s/reannotator.yaml
 #
-#    # Enable after reannotator has completed.
+#    /builder/kubectl.bash create configmap reannotator-config \
+#        --from-file=k8s/reannotator-query-hopannotation1.sql --dry-run -o yaml | \
+#        /builder/kubectl.bash apply -f -
+#
+#    # Jobs cannot be applied before removing the old one.
 #    /builder/kubectl.bash delete job init-job-server
-#    /builder/kubectl.bash delete job renamer
-#    /builder/kubectl.bash apply -f k8s/renamer.yaml
+#    /builder/kubectl.bash delete job reannotator
+#    /builder/kubectl.bash apply -f k8s/reannotator.yaml
 #  env:
 #  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
 #  - CLOUDSDK_CONTAINER_CLUSTER=data-processing
+
+- name: gcr.io/cloud-builders/kubectl
+  id: "Deploy renamer configuration"
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |-
+    sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/g' \
+           -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/g' \
+           k8s/renamer.yaml
+
+    # Enable after reannotator has completed.
+    /builder/kubectl.bash delete job init-job-server
+    /builder/kubectl.bash delete job renamer
+    /builder/kubectl.bash apply -f k8s/renamer.yaml
+  env:
+  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
+  - CLOUDSDK_CONTAINER_CLUSTER=data-processing

--- a/internal/annotation/renamer.go
+++ b/internal/annotation/renamer.go
@@ -114,9 +114,14 @@ func (r *Renamer) Rename(ctx context.Context, url string) (string, error) {
 		// Copy failed, so do not delete source.
 		return "", err
 	}
-	// Delete src object after successful copy.
-	if err := srcObj.Delete(ctx); err != nil {
-		return "", fmt.Errorf("failed to delete object(%q): %w", src, err)
+	for trial := 0; trial < 2; trial++ {
+		// Delete src object after successful copy.
+		err = srcObj.Delete(ctx)
+		if err != nil {
+			log.Printf("Failed to delete object(%q): %v", src, err)
+			continue
+		}
+		break
 	}
 	return dst.String(), err
 }

--- a/k8s/renamer.yaml
+++ b/k8s/renamer.yaml
@@ -13,9 +13,7 @@ spec:
         args:
         # Full history of annotation archives.
         - wget
-        - http://$(JOB_SERVER_PORT_8083_TCP_ADDR):$(JOB_SERVER_PORT_8083_TCP_PORT)/v1/init?start=2019-04-01&end=2023-04-04
-        # TODO(soltesz): operate on fully history of hopannotation1 archives.
-        # - http://$(JOB_SERVER_PORT_8083_TCP_ADDR):$(JOB_SERVER_PORT_8083_TCP_PORT)/v1/init?start=2019-06-04&end=2023-04-04
+        - http://$(JOB_SERVER_PORT_8083_TCP_ADDR):$(JOB_SERVER_PORT_8083_TCP_PORT)/v1/init?start=2019-06-04&end=2023-04-04
       restartPolicy: Never
 ---
 apiVersion: batch/v1
@@ -46,8 +44,8 @@ spec:
         - -jobservice.url=http://$(JOB_SERVER_PORT_8083_TCP_ADDR):$(JOB_SERVER_PORT_8083_TCP_PORT)
         - -prometheusx.listen-address=:9990
         - -output=annotation2-output-{{PROJECT_ID}}
-        - -from-datatype=annotation
-        - -new-datatype=annotation2
+        - -from-datatype=hopannotation1
+        - -new-datatype=hopannotation2
         ports:
         - containerPort: 9990
 


### PR DESCRIPTION
This change updates the renamer ocnfiguration to rename the reannotated hopannotation1 to hopannotation2.

This change also adds a retry around the delete operation. The renamer run for annotation2 datatype found this to be the largest source of process failures due to an internal 10sec timeout for delete operations. This retry is expected to make the operation more reliable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/archive-repacker/28)
<!-- Reviewable:end -->
